### PR TITLE
fix links

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -113,7 +113,7 @@ Before using the Anaconda Build System:
    queues, at
    `anaconda.org/new/organization <https://anaconda.org/new/organization>`__
 
-
+.. _submit-a-build:
 
 Submit a build
 ~~~~~~~~~~~~~~
@@ -214,14 +214,14 @@ Install your new conda package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default Anaconda Cloud puts all new packages in a ``dev`` label in
-your account. See `Using labels in the development
-cycle <using.html#UsingLabelsInTheDevelopmentCycle>`__ for a more in
+your account. See :ref:`using-labels-in-the-development-cycle` for a more in
 depth example on how to use labels.
 
 ::
 
     conda install -c USERNAME/label/dev conda_build_test
 
+.. _github-builds:
 
 GitHub builds
 ~~~~~~~~~~~~~
@@ -255,17 +255,18 @@ github url.
 
     anaconda build submit https://github.com/GITHUB_USERNAME/conda_build_test
 
+.. _save-and-trigger-builds:
 
 Save and trigger your builds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once you have `submitted a build from github <#GithubBuilds>`__ you may
 want to save your build configuration, especially if you are using
-`extra options </cli.html#Submit>`__ like ``-p``, ``--sub-dir``,
+:ref:`extra options <cli-submit>` like ``-p``, ``--sub-dir``,
 ``--label``, ``--queue`` or ``--email``.
 
-You can `save </cli.html#Save>`__ these options to Anaconda Cloud and
-`trigger </cli.html#Trigger>`__ them later.
+You can :ref:`cli-save` these options to Anaconda Cloud and
+:ref:`cli-trigger>` them later.
 
 Note: Using the anaconda build save command affects the Continuous
 Integration (CI) section of the package settings on Anaconda Cloud. For
@@ -446,8 +447,8 @@ build\_targets
 ^^^^^^^^^^^^^^
 
 These files will be uploaded to your Anaconda Cloud package. These are
-files that will be uploaded to Anaconda Cloud with `anaconda
-upload </cli.html#Upload>`__.
+files that will be uploaded to Anaconda Cloud with :ref:`anaconda
+upload <cli-upload>`.
 
 You may use the key words ``conda`` or ``pypi``:
 
@@ -476,8 +477,8 @@ available for public use on Anaconda Cloud. You can `add your own build
 workers <#LaunchingABuildWorker>`__ if you need access to additional
 platforms.
 
-To see which platforms are available to you, issue the `anaconda build
-queue </cli.html#Queue>`__ command:
+To see which platforms are available to you, issue the :ref:`anaconda build
+queue <cli-queue>` command:
 
 ::
 
@@ -559,7 +560,7 @@ This shows the install\_channels configured for building R packages.
 YAML
 
 If private packages are required in your build, make sure to include a
-`token <reference.html#Token>`__ in the channel configuration.
+:ref:`token <reference-token>` in the channel configuration.
 
 This shows the install\_channels configured for building a package that
 depends on jsmith's private packages.
@@ -702,6 +703,8 @@ CONDA\_NPY
     The conda numpy version from the engine tag
 
 
+.. _build-workers:
+
 Build workers
 =============
 
@@ -715,16 +718,16 @@ Cloud <http://anaconda.org>`__ provides free linux-64 workers. If you do
 **not** need to build for other platforms, you can complete package
 builds using only `Anaconda Cloud <http://anaconda.org>`__. Further, all
 Anaconda Cloud accounts allow you to attach one free worker. If you need
-more workers or workers on other platforms, you will need to `create an
-organization </using.html#CreatingOrganizations>`__ and `upgrade to a
+more workers or workers on other platforms, you will need to :ref:`create an
+organization <creating-orgs>` and `upgrade to a
 paid plan <https://anaconda.org/about/pricing>`__.
 
 Anaconda build workers allow you to run your builds on your own
 machines. A build worker can run on any machine that supports bash
 (posix) or batch (win32).
 
-To follow along with this tutorial, you will need to `install the build
-cli </using.html#InstallingAnacondaClientAndAnacondaBuild>`__.
+To follow along with this tutorial, you will need to :ref:`install the build
+cli <installing-anaconda-client-and-anaconda-build>`.
 
 
 Create a build queue
@@ -904,8 +907,8 @@ Configuring build queues
 By default your build worker will run builds on your ``binstar/public``
 queue. You may change this in two ways:
 
-#. Use the ``--queue`` option when issuing a ``anaconda build`` `submit,
-   save or trigger <cli.html#SubmittingBuilds>`__ command:
+#. Use the ``--queue`` option when issuing a ``anaconda build`` :doc:`submit,
+   save or trigger <submitting-builds>` command:
 
    ::
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -397,6 +397,8 @@ Anaconda Cloud package utilities
     authorized and authenticated access to install
 
 
+.. _cli-upload:
+
 upload
 ^^^^^^
 
@@ -578,36 +580,36 @@ Anaconda build client for continuous integration, testing and building packages
 
 | **Commands:**
 
-`backlog <cli.html#Backlog>`__
+backlog
     Run a build worker to build jobs off of a anaconda build queue
-`build <cli.html#Build>`__
+build
     Anaconda build client for continuous integration, testing and
     building packages
-`init <cli.html#Init>`__
+init
     Initialize Build file
-`keyfile <cli.html#Keyfile>`__
+keyfile
     [Advanced] Not documented yet
-`keyfiles <cli.html#Keyfiles>`__
+keyfiles
     [Advanced] Not documented yet
-`list <cli.html#List>`__
+list
     list the builds for package
-`list-all <cli.html#List-All>`__
+list-all
     list the builds for package
-`queue <cli.html#Queue>`__
+queue
     Inspect build queue
-`resubmit <cli.html#Resubmit>`__
+resubmit
     Resubmit build
-`results <cli.html#Results>`__
+results
     [Advanced] Attach results to build
-`save <cli.html#Save>`__
+save
     Save build info to be triggered later
-`submit <cli.html#Submit>`__
+submit
     Submit a directory or github repo for building
-`tail <cli.html#Tail>`__
+tail
     Tail the build output of build number X.Y
-`trigger <cli.html#Trigger>`__
+trigger
     Trigger a build that has been saved
-`worker <cli.html#Worker>`__
+worker
     Anaconda build client for continuous integration, testing and
     building packages
 
@@ -623,15 +625,14 @@ To get started with anaconda build run:
 
 See also:
 
--  `Anaconda Build </building.html>`__
+-  :doc:`build`
 
-| 
-| `  <cli.html#SubmittingBuilds>`__
+.. _submitting-builds:
 
 Submitting Builds
 ~~~~~~~~~~~~~~~~~
 
-`  <cli.html#Submit>`__
+.. _cli-submit:
 
 submit
 ^^^^^^
@@ -712,12 +713,12 @@ Submit a build from your local path or via a git url:
 
 See also:
 
--  `Submit A Build </build.html#SubmitABuild>`__
--  `Submit A Build From Github </build.html#GithubBuilds>`__
+-  :ref:`submit-a-build`
+-  :ref:`Submit A Build From Github <github-builds>`
 
 | 
 
-`  <cli.html#Save>`__
+.. _cli-save:
 
 save
 ^^^^
@@ -760,12 +761,11 @@ Save build info to be triggered later
 
 See also:
 
--  `Save and Trigger Your
-   Builds </build.html#SaveAndTriggerYourBuilds>`__
+-  :ref:`save-and-trigger-builds`
 
 | 
 
-`  <cli.html#Trigger>`__
+.. _cli-trigger:
 
 trigger
 ^^^^^^^
@@ -827,16 +827,12 @@ Trigger a build that has been saved
 
 See also:
 
--  `Save and Trigger Your
-   Builds </build.html#SaveAndTriggerYourBuilds>`__
-
-| 
-| `  <cli.html#HostingBuildMachines>`__
+-  :ref:`save-and-trigger-builds`
 
 Hosting Build machines
 ~~~~~~~~~~~~~~~~~~~~~~
 
-`  <cli.html#Queue>`__
+.. _cli-queue:
 
 queue
 ^^^^^
@@ -861,8 +857,6 @@ USERNAME/QUEUENAME
 
 | 
 
-`  <cli.html#Worker>`__
-
 worker
 ^^^^^^
 
@@ -875,16 +869,16 @@ None
 
 | **Commands:**
 
-`deregister <cli.html#Deregister>`__
+deregister
     Deregister a build worker to build jobs off of a binstar build queue
-`docker\_run <cli.html#Docker_Run>`__
+docker_run
     Run a build worker in a docker container to build jobs off of a
     binstar build queue
-`list <cli.html#List>`__
+list
     List build workers and queues
-`register <cli.html#Register>`__
+register
     Register a build worker to build jobs off of a binstar build queue
-`run <cli.html#Run>`__
+run
     Run a build worker to build jobs off of a binstar build queue
 
 | 
@@ -899,11 +893,9 @@ To get started with anaconda worker run:
 
 See also:
 
--  `Anaconda Build </build-config.html#BuildWorkers>`__
+-  :ref:`Anaconda Build <build-workers>`
 
 | 
-
-`  <cli.html#DockerWorker>`__
 
 docker-worker
 ^^^^^^^^^^^^^

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -148,8 +148,7 @@ Manage Authentication tokens
 
 See also:
 
--  `Using Anaconda Cloud
-   Tokens <http://docs.anaconda.org/using.html#Tokens>`__
+-  :ref:`Using Anaconda Cloud Tokens <using-tokens>`
 
 
 login
@@ -475,10 +474,8 @@ Upload packages to Anaconda Cloud
 See Also
 ''''''''
 
--  `Uploading a Conda
-   Package <http://docs.anaconda.org/using.html#Uploading>`__
--  `Uploading a PyPI
-   Package <http://docs.anaconda.org/using.html#UploadingPypiPackages>`__
+-  :ref:`Uploading a Conda Package <uploading-conda-packages>`
+-  :ref:`Uploading a PyPI Package <uploading-pypi-packages>`
 
 
 label

--- a/docs/managing-account.rst
+++ b/docs/managing-account.rst
@@ -70,7 +70,7 @@ From left to right, the user toolbar options are:
 Packages that you have created with this account appear on your
 Dashboard. There’s a handy button to create a new package.
 
-See Also: `Working with Packages </using.html#Packages>`__
+See Also: :ref:`Working with Packages <using-packages>`
 
 
 Reset password

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,10 +59,8 @@ EXAMPLE: To download and install a package with conda, run:
 Conda expands "username" to a URL such as
 "https://anaconda.org/username" based on the settings in the .condarc
 file. Anaconda Cloud users can use the defaults, and Anaconda Enterprise
-repository users can `configure the
-repository <https://docs.continuum.io/anaconda-repository/configuration>`__
-or `configure
-conda <http://conda.pydata.org/docs/config.html#set-a-channel-alias-channel-alias>`__
+repository users can :doc:`configure the repository </anaconda-repository/configuration>` 
+or `configure conda <http://conda.pydata.org/docs/config.html#set-a-channel-alias-channel-alias>`__
 to use their local installation.
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,8 +12,8 @@ Search for a public package
 Python packages for a wide variety of applications. You don't need an
 Anaconda Cloud account, or to be logged in, to search for public
 packages, download and install them. You need an account only to access
-`private packages <using.html#PrivatePackages>`__ without a
-`token <using.html#Tokens>`__, or to build and share your packages with
+:ref:`private packages <using-private-packages>` without a
+:ref:`token <using-tokens>`, or to build and share your packages with
 others.
 
 #. In the top search box, type part or all of the name of a program you
@@ -63,6 +63,7 @@ repository users can :doc:`configure the repository </anaconda-repository/config
 or `configure conda <http://conda.pydata.org/docs/config.html#set-a-channel-alias-channel-alias>`__
 to use their local installation.
 
+.. _quickstart-build-upload:
 
 Build and upload packages
 =========================
@@ -120,8 +121,7 @@ and upload your newly built test package to your Anaconda Cloud account:
       anaconda login
       anaconda upload /your/path/conda-package.tar.bz2
 
-For detailed information, see the `Conda
-packages <using.html#CondaPackages>`__ section.
+For detailed information, see the :ref:`using-conda-packages` section.
 
 
 Share notebooks

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -30,11 +30,8 @@ To install a conda package, in your terminal window run:
 Conda expands "username" to a URL such as
 "https://anaconda.org/username" or "https://conda.anaconda.org/username"
 based on the settings in the .condarc file. Anaconda Cloud users can use
-the defaults, and Anaconda Enterprise repository users can `configure
-the
-repository <https://docs.continuum.io/anaconda-repository/configuration>`__
-or `configure
-conda <http://conda.pydata.org/docs/config.html#set-a-channel-alias-channel-alias>`__
+the defaults, and Anaconda Enterprise repository users can :doc:`configure the repository </anaconda-repository/configuration>` 
+or `configure conda <http://conda.pydata.org/docs/config.html#set-a-channel-alias-channel-alias>`__
 to use their local installation.
 
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -54,8 +54,8 @@ Install anaconda-client
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The anaconda-client command line interface (CLI) is available via conda
-or pip. See `installation and setup
-instructions </using.html#InstallingAnacondaClientAndAnacondaBuild>`__.
+or pip. See :ref:`installation and setup
+instructions <installing-anaconda-client-and-anaconda-build>`.
 
 
 Find my anaconda-client login credentials
@@ -140,9 +140,9 @@ Build packages
 Build and upload a package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See the `Anaconda Cloud Build Guide </build.html>`__ for step-by-step
-instructions. For a quick run-through, try the Quickstart `build guide
-section </quickstart.html#BuildAndUploadPackages>`__.
+See the :doc:`Anaconda Cloud Build Guide <build>` for step-by-step
+instructions. For a quick run-through, try the Quickstart :ref:`build guide
+section <quickstart-build-upload>`.
 
 `  <#TestABuiltPackage>`__
 
@@ -288,8 +288,7 @@ How do I get started with Anaconda Cloud?
 You can search, download and install hundreds of public packages without
 even having an account. If you wish to build and upload packages, you
 will need to sign up for an `Anaconda Cloud
-account <https://anaconda.org/>`__. See our `Using Anaconda Cloud
-section </using.html>`__ for more help.
+account <https://anaconda.org/>`__. See our :doc:`using` section for more help.
 
 `  <#WhatKindOfAccountDoIHave>`__
 
@@ -555,7 +554,7 @@ Source package
 platform, and might be compatible with all, some, or only one of the
 platforms.
 
-`  <#Token>`__
+.. _reference-token:
 
 Token
 ~~~~~

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -8,6 +8,8 @@ Getting started
 Overview
 ~~~~~~~~
 
+.. _installing-anaconda-client-and-anaconda-build:
+
 Installing anaconda-client and anaconda-build
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -54,6 +56,7 @@ gcc-c++, git, and subversion:
 
     yum install -y tar bzip2 ntp chrpath wget dos2unix patch gcc gcc-c++ git subversion
 
+.. _using-packages:
 
 Packages
 ========
@@ -74,8 +77,8 @@ NOTE: All packages are public if uploaded by users of free accounts.
 Packages may be designated as private by upgrading to a paid account.
 
 Anaconda Cloud supports two package managers,
-`conda <using.html#CondaPackages>`__ and
-`PyPI <using.html#PypiPackages>`__. To work with conda or PyPI packages,
+:ref:`conda <using-conda-packages>` and
+:ref:`PyPI <using-pypi-packages>`. To work with conda or PyPI packages,
 you must use their corresponding subdomains:
 
 -  To install **conda** packages from the conda user, use the repository
@@ -121,6 +124,7 @@ with a channel and a label:
      conda install —-channel sean selenium
      conda install —-channel sean/label/dev selenium
 
+.. _using-conda-packages:
 
 Conda packages
 ~~~~~~~~~~~~~~
@@ -174,8 +178,8 @@ directory. You can check where the resulting file was placed with the
 
       conda build . --output
 
-Now upload the test package to Anaconda Cloud with the `anaconda
-upload <cli.html#Upload>`__ command:
+Now upload the test package to Anaconda Cloud with the :ref:`anaconda
+upload <cli-upload>` command:
 
 ::
 
@@ -211,6 +215,7 @@ package <https://anaconda.org/sean/testci>`__:
 
       conda install testci
 
+.. _using-pypi-packages:
 
 PyPI packages
 ~~~~~~~~~~~~~
@@ -269,14 +274,15 @@ private packages:
       TOKEN=$(anaconda auth --create --name YOUR-TOKEN-NAME)
       pip install --index-url https://pypi.anaconda.org/t/$TOKEN/USERNAME/simple test-package
 
+.. _using-private-packages:
 
 Private packages
 ~~~~~~~~~~~~~~~~
 
 Packages may be private. This means that a user must explicitly have
 access to view the package. To view and install private packages, you
-must identify yourself to Anaconda Cloud. This is done with `access
-tokens <using.html#Tokens>`__. Once you have generated a token
+must identify yourself to Anaconda Cloud. This is done with :ref:`access
+tokens <using-tokens>`. Once you have generated a token
 (``<TOKEN>``), you may prefix any repository url with ``/t/<TOKEN>``
 
 Note: This is just an example. You will not see any extra private
@@ -338,8 +344,8 @@ Uploading packages
 ~~~~~~~~~~~~~~~~~~
 
 To easily upload package files to Anaconda Cloud use the
-`anaconda-client <cli.html>`__ command line interface and the
-`upload <cli.html#Upload>`__ command:
+:doc:`anaconda-client <cli>` command line interface and the
+:ref:`upload <cli-upload>` command:
 
 ::
 
@@ -367,7 +373,7 @@ files to Anaconda Cloud. In this example we will upload a spreadsheet
 named baby-names in comma separated value (CSV) format. Any type of file
 can be uploaded with the Anaconda CLI by using these steps.
 
-#. Use the `anaconda-client <cli.html>`__ command line interface to
+#. Use the :doc:`anaconda-client <cli>` command line interface to
    create a new namespace for your file on Anaconda Cloud:
 
    ::
@@ -415,7 +421,7 @@ To remove a past version of one of your packages from Anaconda Cloud:
 
 #. Click the "Actions" menu and then "Remove".
 
-You may instead use the `command line interface <cli.html>`__:
+You may instead use the :doc:`command line interface <cli>`:
 
 ::
 
@@ -442,7 +448,7 @@ versions:
 
 #. Click "Delete".
 
-You may instead use the `command line interface <cli.html>`__:
+You may instead use the :doc:`command line interface <cli>`:
 
 ::
 
@@ -509,6 +515,7 @@ Organizations
 
 Organizations enable you to maintain group-owned repositories.
 
+.. _creating-orgs:
 
 Creating organizations
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -567,6 +574,7 @@ To upload a package to an organization, use the ``-u/--user`` option:
 
     anaconda upload --user USERNAME package.tar.bz2
 
+.. _using-labels-in-the-development-cycle:
 
 Using labels in the development cycle
 =====================================
@@ -600,7 +608,7 @@ conda package. Before you build the package edit the version in the
     conda build .
 
 Now, upload your test package to Anaconda Cloud using the
-`anaconda-client upload <cli.html#Upload>`__ command.
+:ref:`anaconda-client upload <cli-upload>` command.
 
 Adding the ``--label`` option tells Anaconda Cloud to make the upload
 visible only to users who specify that label.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -125,6 +125,8 @@ with a channel and a label:
 Conda packages
 ~~~~~~~~~~~~~~
 
+.. _uploading-conda-packages:
+
 Uploading
 ^^^^^^^^^
 
@@ -164,7 +166,7 @@ command:
       conda build .
 
 All packages built in this way are placed in a subdirectory of
-`Anaconda's <http://docs.continuum.io/anaconda/index>`__ *conda-bld*
+:doc:`Anaconda's </anaconda/index>` *conda-bld*
 directory. You can check where the resulting file was placed with the
 ``--output`` option:
 
@@ -212,6 +214,8 @@ package <https://anaconda.org/sean/testci>`__:
 
 PyPI packages
 ~~~~~~~~~~~~~
+
+.. _uploading-pypi-packages:
 
 Uploading PyPI packages
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -285,6 +289,7 @@ packages in the travis **user namespace**.
    repository url
    `https://\ **pypi**.anaconda.org/t/<TOKEN>/travis <https://pypi.anaconda.org/travis>`__
 
+.. _using-tokens:
 
 Tokens
 ~~~~~~


### PR DESCRIPTION
fix links to docs.anaconda.org and docs.continuum.io